### PR TITLE
Fix issue with blender_vscode

### DIFF
--- a/addons/blender_xatlas/__init__.py
+++ b/addons/blender_xatlas/__init__.py
@@ -47,7 +47,13 @@ import uuid
 
 
 import importlib
-sys.path.append(__path__)
+
+# make sure __path__ is not a list here, to prevent crash when using blender_vscode
+__safe_path__ = __path__
+if type(__safe_path__) == list:
+    __safe_path__ = __safe_path__[0]
+
+sys.path.append(__safe_path__)
 from . import export_obj_simple
 
 importlib.reload(export_obj_simple)


### PR DESCRIPTION
When developing a plugin with https://github.com/JacquesLucke/blender_vscode , having xatlas enabled will cause blender to close on launch,
because of an error where `__path__` is a list